### PR TITLE
Least-privilege IAM for Lambda DynamoDB reads

### DIFF
--- a/infra/iam/policies/fetchSensorData-read.json
+++ b/infra/iam/policies/fetchSensorData-read.json
@@ -1,0 +1,9 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "ReadSensorDataBySession",
+    "Effect": "Allow",
+    "Action": ["dynamodb:Query"],
+    "Resource": ["arn:aws:dynamodb:us-east-2:623626440685:table/sensor_data", "arn:aws:dynamodb:us-east-2:623626440685:table/sensor_data/index/*"]
+  }]
+}

--- a/infra/iam/policies/lambda_meat_data-read.json
+++ b/infra/iam/policies/lambda_meat_data-read.json
@@ -1,0 +1,9 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "ReadMeatTypes",
+    "Effect": "Allow",
+    "Action": ["dynamodb:GetItem","dynamodb:Query","dynamodb:Scan"],
+    "Resource": ["arn:aws:dynamodb:us-east-2:623626440685:table/meat_types", "arn:aws:dynamodb:us-east-2:623626440685:table/meat_types/index/*"]
+  }]
+}


### PR DESCRIPTION
Attach table-scoped policies; removed broad AWS managed policies.