### PR TITLE
DynamoDB: probe_assignments table spec

### DIFF
--- a/infra/ddb/tables/probe_assignments.json
+++ b/infra/ddb/tables/probe_assignments.json
@@ -1,0 +1,12 @@
+{
+  "TableName": "probe_assignments",
+  "BillingMode": "PAY_PER_REQUEST",
+  "AttributeDefinitions": [
+    { "AttributeName": "session_id", "AttributeType": "S" },
+    { "AttributeName": "probe_id",   "AttributeType": "S" }
+  ],
+  "KeySchema": [
+    { "AttributeName": "session_id", "KeyType": "HASH" },
+    { "AttributeName": "probe_id",   "KeyType": "RANGE" }
+  ]
+}


### PR DESCRIPTION
Tracks per-session probe assignments; PAY_PER_REQUEST; PK=session_id, SK=probe_id.