### PR TITLE
hotfix: session selector LIVE badge respects actual session status

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -256,6 +256,7 @@ export default function App() {
             selectedId={selectedSessionId || sessionId}
             onSelect={handleSessionSelect}
             loading={sessionsLoading}
+            sessionActive={sessionActive}
           />
           {!isLive && (
             <button className="back-to-live-btn" onClick={() => setSelectedSessionId(sessionId)}>

--- a/src/components/SessionSelector/SessionSelector.jsx
+++ b/src/components/SessionSelector/SessionSelector.jsx
@@ -12,7 +12,7 @@ import './SessionSelector.css';
  *   onSelect     {func}    called with session_id string when user picks one
  *   loading      {bool}    show loading state while sessions are fetching
  */
-export default function SessionSelector({ sessions, currentId, selectedId, onSelect, loading }) {
+export default function SessionSelector({ sessions, currentId, selectedId, onSelect, loading, sessionActive }) {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
 
@@ -27,7 +27,7 @@ export default function SessionSelector({ sessions, currentId, selectedId, onSel
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
-  const isLive = selectedId === currentId;
+  const isLive = selectedId === currentId && sessionActive;
   const label = loading
     ? 'Loading sessions…'
     : isLive
@@ -66,10 +66,10 @@ export default function SessionSelector({ sessions, currentId, selectedId, onSel
                 <span className="session-selector__item-label">
                   {fmtSessionId(s.session_id)}
                 </span>
-                {isCurrent && (
+                {isCurrent && sessionActive && (
                   <span className="session-selector__badge session-selector__badge--live">LIVE</span>
                 )}
-                {!isCurrent && s.status && (
+                {(!isCurrent || !sessionActive) && s.status && (
                   <span className="session-selector__badge">{s.status}</span>
                 )}
               </li>


### PR DESCRIPTION
## Summary
- SessionSelector was showing LIVE for the latest session regardless of whether the smokehouse was actually running
- Now uses `sessionActive` prop (from SessionsLatest `status` field) to gate the LIVE badge in both the dropdown trigger label and the session list items

## Test plan
- [ ] March 18 session shows as "ended" in dropdown, not LIVE
- [ ] Dropdown trigger shows "(historical)" not "LIVE —" for stale sessions
- [ ] LIVE badge appears correctly when a real smoke is in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)