### PR TITLE
hotfix: refresh data when switching between historical sessions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -153,7 +153,11 @@ export default function App() {
     return () => { if (timerRef.current) clearInterval(timerRef.current); };
   }, [refreshData, isLive]);
 
-  const handleSessionSelect = useCallback((sid) => setSelectedSessionId(sid), []);
+  const handleSessionSelect = useCallback((sid) => {
+    selectedSessionIdRef.current = sid;
+    setSelectedSessionId(sid);
+    refreshData();
+  }, [refreshData]);
 
   const handleApplyPitTemp = useCallback(async (tempF) => {
     setTargetPitTempF(String(tempF));


### PR DESCRIPTION
## Summary
- Selecting a historical session from the dropdown wasn't reloading the chart/probe data
- `handleSessionSelect` only updated state; since `isLive` didn't change between two historical sessions the refresh effect never re-fired
- Fix: update the session ref and call `refreshData` directly on selection

## Test plan
- [ ] Select Dec 25 session — chart and probe data update
- [ ] Switch to Nov 27 session — chart and probe data update again
- [ ] Switch back to live — data refreshes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)